### PR TITLE
No placeholder for text needed for input:t

### DIFF
--- a/html.json
+++ b/html.json
@@ -60,7 +60,7 @@
 	"input": "input[type=${1:text}]/",
 	"inp": "input[name=${1} id=${1}]",
 	"input:h|input:hidden": "input[type=hidden name]",
-	"input:t|input:text": "inp",
+	"input:t|input:text": "inp[type=text]",
 	"input:search": "inp[type=search]",
 	"input:email": "inp[type=email]",
 	"input:url": "inp[type=url]",


### PR DESCRIPTION
_From @DiscreteChi in https://github.com/Microsoft/vscode/issues/34352_

`input:t` expands to `<input type="${1:text}" name="${2}" id="${3}">`

The placeholder on the "text" is not needed as the abbreviation specifically asks for the text type.

For example `input:date` doesnt result in placeholder for `date`. It simply expands to `<input type="date" name="${1}" id="${2}">`

cc @sergeche 