### PR TITLE
Adding missing bds none snippet

### DIFF
--- a/css.json
+++ b/css.json
@@ -46,7 +46,7 @@
 	"bdrs": "border-radius",
 	"bdrst": "border-right-style",
 	"bdrw": "border-right-width",
-	"bds": "border-style:hidden|dotted|dashed|solid|double|dot-dash|dot-dot-dash|wave|groove|ridge|inset|outset",
+	"bds": "border-style:none|hidden|dotted|dashed|solid|double|dot-dash|dot-dot-dash|wave|groove|ridge|inset|outset",
 	"bdsp": "border-spacing",
 	"bdt": "border-top:${1:1px} ${2:solid} ${3:#000}",
 	"bdtc": "border-top-color:#${1:000}",


### PR DESCRIPTION
`border-style: none` is missing

cc @sergeche