### PR TITLE
Adds a:blank HTML shortcut

### DIFF
--- a/html.json
+++ b/html.json
@@ -1,5 +1,6 @@
 {
 	"a": "a[href]",
+	"a:blank": "a[href='http://${0}' target='_blank' rel='noopener noreferrer']",
 	"a:link": "a[href='http://${0}']",
 	"a:mail": "a[href='mailto:${0}']",
 	"a:tel": "a[href='tel:+${0}']",


### PR DESCRIPTION
This adds an expansion for a href target="_blank" rel="noopener noreferrer"

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
(When using target, consider adding rel="noopener noreferrer" to avoid exploitation of the window.opener API.)