### PR TITLE
Updated fz to fsz

### DIFF
--- a/css.json
+++ b/css.json
@@ -118,7 +118,7 @@
 	"fxg": "flex-grow",
 	"fxsh": "flex-shrink",
 	"fxw": "flex-wrap:nowrap|wrap|wrap-reverse",
-	"fz": "font-size",
+	"fsz": "font-size",
 	"fza": "font-size-adjust",
 	"h": "height",
 	"jc": "justify-content:flex-start|flex-end|center|space-between|space-around",


### PR DESCRIPTION
This PR addresses https://github.com/Microsoft/vscode/issues/59951.

It changes `fz` to `fsz`.  This will allow for `fsz` to be expanded to `font-size` instead of `font-style`.

The underlying search still needs to be changed and I’ll take a look over the next couple of days to see what I can do.
