### PR TITLE
Remove X-UA-Compatible tag in head

### DIFF
--- a/html.json
+++ b/html.json
@@ -141,7 +141,7 @@
 	"ri:t|ri:type": "pic>src:t+img",
 
 	"!!!": "{<!DOCTYPE html>}",
-	"doc": "html[lang=${lang}]>(head>meta[charset=${charset}]+meta:vp+meta:edge+title{${1:Document}})+body",
+	"doc": "html[lang=${lang}]>(head>meta[charset=${charset}]+meta:vp+title{${1:Document}})+body",
 	"!|html:5": "!!!+doc",
 
 	"c": "{<!-- ${0} -->}",


### PR DESCRIPTION
This expansion adds `<meta http-equiv="X-UA-Compatible" content="ie=edge">` to the head of the document.I don't think this needs to be part of the default `!+tab` expansion anymore. 

A few reasons why:

* The last browser that uses this is IE10 
* Chrome frame was retired over 5 years ago

Some more discussion from many years ago: https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do

Can we remove it so I can stop deleting it after each expansion? 